### PR TITLE
renderDynamic break

### DIFF
--- a/framework/base/View.php
+++ b/framework/base/View.php
@@ -364,7 +364,7 @@ class View extends Component
     public function renderDynamic($statements, array $params = [])
     {
         if (!empty($params)) {
-            $statements = 'extract(unserialize(\'' . serialize($params) . '\'));' . $statements;
+            $statements = 'extract(unserialize(\'' . str_replace(['\\', '\'' ], ['\\\\', '\\\'' ], serialize($params)) . '\'));' . $statements;
         }
         if (!empty($this->cacheStack)) {
             $n = count($this->dynamicPlaceholders);


### PR DESCRIPTION
renderDynamic break while params inside contain string with quote
coz when the string concat then evaluate, it will break the closing quote

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
